### PR TITLE
Added new React course

### DIFF
--- a/src/components/data/allcourses.json
+++ b/src/components/data/allcourses.json
@@ -1094,6 +1094,12 @@
                     "name": "FreeCodeCamp offers certifcations for react",
                     "source": "FreeCodeCamp",
                     "link": "https://www.freecodecamp.org/learn/front-end-development-libraries/#sass"
+                },
+                 {
+                    "icon": "fab fa-react",
+                    "name": "React",
+                    "source": "Harvard University",
+                    "link": "https://pll.harvard.edu/course/cs50s-mobile-app-development-react-native?delta=0"
                 }
             ]
         },


### PR DESCRIPTION
CS50’s Mobile App Development with React Native on edX

This course will help learners from transitioning web development to mobile app development with React Native. It offers hands-on projects so that you can gain experience with React and its paradigms, app architecture, and user interfaces. 

Course Duration: 13 Weeks [Effort: 6-9 hours per week]
Level: Intermediate

What Will One Learn: 
 -JavaScript
-ES6
-React, JSX
-Debugging
-Redux
PLEASE MERGE THIS PULL REQUEST
