### PR TITLE
Added Advanced SQL free certification course

### DIFF
--- a/README.md
+++ b/README.md
@@ -1545,6 +1545,12 @@ Website - https://www.simplilearn.com/free-generative-ai-course-skillup<br>
  Website- https://skillsbuild.org/students/course-catalog/artificial-intelligence
 </details>
 
+<details>
+ <summary>Advanced SQL</summary>
+ <br>
+ Website- https://www.kaggle.com/learn/advanced-sql
+</details>
+
 ### License 
 
 This project is licensed under the [MIT License](./LICENSE).

--- a/src/components/data/allcourses.json
+++ b/src/components/data/allcourses.json
@@ -117,6 +117,12 @@
           "source": "GeeksforGeeks",
           "link": "https://www.geeksforgeeks.org/batch/skill-up-sql"
         }
+        ,{
+          "icon": "fa-solid fa-database",
+          "name": "Advanced SQL",
+          "source": "Kaggle",
+          "link": "https://www.kaggle.com/learn/advanced-sql"
+        }
     ]
   },
   {


### PR DESCRIPTION
Issue #778 

- Added Free **Advanced SQL certification course** instead of **Free Python certification course** from kaggle since it already existed in the learning resources

Thankyou!