### PR TITLE
Add ChatGPT Prompt Engineering for Developers Course from DeepLearning.AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ Website- https://infyspringboard.onwingspan.com/web/en/app/toc/lex_auth_01330144
 GREAT LEARNING ACADEMY- Introduction to Deep Learning<br>
 Website-https://www.greatlearning.in/academy/learn-for-free/courses/introduction-to-deep-learning<br>
 <br>
+DeepLearning.AI - ChatGPT Prompt Engineering for Developers<br>
+Website-https://learn.deeplearning.ai/courses/chatgpt-prompt-eng<br>
+<br>
 GREAT LEARNING ACADEMY- Computer Vision Essentials<br>
 Website- https://www.greatlearning.in/academy/learn-for-free/courses/computer-vision-essentials<br>
 <br>

--- a/src/components/data/allcourses.json
+++ b/src/components/data/allcourses.json
@@ -268,6 +268,12 @@
       },
       {
         "icon": "fa-solid fa-brain",
+        "name": "ChatGPT Prompt Engineering for Developers",
+        "source": "DeepLearning.AI",
+        "link": "https://learn.deeplearning.ai/courses/chatgpt-prompt-eng"
+      },
+      {
+        "icon": "fa-solid fa-brain",
         "name": "Computer Vision Essentials",
         "source": "Great Learning Academy",
         "link": "https://www.greatlearning.in/academy/learn-for-free/courses/computer-vision-essentials"


### PR DESCRIPTION
## Description
Added ChatGPT Prompt Engineering for Developers course from DeepLearning.AI to the Artificial Intelligence section.

## Related Issue
Closes #841

## Changes Made
- ✅ Added course to [src/components/data/allcourses.json]
- ✅ Added course to [README.md]
- ✅ Followed all contribution guidelines

## Course Details
- **Name:** ChatGPT Prompt Engineering for Developers
- **Source:** DeepLearning.AI
- **Category:** Artificial Intelligence
- **Link:** https://learn.deeplearning.ai/courses/chatgpt-prompt-eng
- **Free:** Yes
- **Certificate:** Yes

## Checklist
- [x] Created an issue before contributing
- [x] Added course to both required files
- [x] Verified course link is working
- [x] Followed existing format and structure